### PR TITLE
Fix Dockerfile

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -4,6 +4,7 @@ FROM golang:1.21.5-alpine AS build-stage
 WORKDIR /app
 
 RUN apk add --update nodejs npm gcc g++ musl-dev git
+RUN go install github.com/a-h/templ/cmd/templ@latest
 RUN CGO_ENABLED=1 go install -tags extended github.com/gohugoio/hugo@latest
 ENV PATH="/go/bin:${PATH}"
 


### PR DESCRIPTION
The `templ` package, which was added in the previous commit, was forgotten in the Dockerfile. The nightly build succeeded even though the Docker build failed. This change should fix it.