### PR TITLE
Add debug instructions for vscode users

### DIFF
--- a/.vscode/how-to-debug.txt
+++ b/.vscode/how-to-debug.txt
@@ -1,0 +1,7 @@
+For VS Code users.
+
+To debug:
+1. Build the debug recipya: task build-debug
+2. Start recipya: ./bin/recipya_debug serve
+3. Press F5 to start the VS Code debugger
+4. Select the recipya_debug process from the list

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Attach to Process",
+            "type": "go",
+            "request": "attach",
+            "mode": "local",
+            "processId": 0,
+        }
+    ]
+}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,6 +8,14 @@ tasks:
       - cmd: go build -ldflags="-s -w" -o bin/recipya main.go
         platforms: [ linux, darwin ]
 
+  build-debug:
+    cmds:
+      - cmd: go generate ./...
+      - cmd: go build -gcflags=all="-N -l" -o bin/recipya_debug.exe main.go
+        platforms: [ windows ]
+      - cmd: go build -gcflags=all="-N -l" -o bin/recipya_debug main.go
+        platforms: [ linux, darwin ]
+
   cover:
     cmds:
       - cmd: go test ./... -coverprofile=coverage.out


### PR DESCRIPTION
To debug:
1. Build the debug recipya: task build-debug
2. Start recipya: ./bin/recipya_debug serve
3. Press F5 to start the VS Code debugger
4. Select the recipya_debug process from the list