### PR TITLE
Fix database locked error when adding many recipes

### DIFF
--- a/internal/server/handlers_recipes.go
+++ b/internal/server/handlers_recipes.go
@@ -148,7 +148,7 @@ func (s *Server) recipesAddImportHandler(w http.ResponseWriter, r *http.Request)
 
 				id, err := s.Repository.AddRecipe(&r, userID, settings)
 				if err != nil {
-					fmt.Println(err)
+					fmt.Println(r.Name, err)
 					return
 				}
 

--- a/internal/server/handlers_settings.go
+++ b/internal/server/handlers_settings.go
@@ -168,7 +168,6 @@ func (s *Server) settingsMeasurementSystemsPostHandler(w http.ResponseWriter, r 
 		return
 	}
 
-	w.Header().Set("HX-Trigger", makeToast("Measurement system set to "+system.String()+".", infoToast))
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -268,16 +268,18 @@ func (s *Server) Run() {
 		serverStopCtx()
 	}()
 
-	err := s.Repository.InitAutologin()
-	if err != nil {
-		fmt.Printf("Could not initialize the autologin feature: %q\n", err)
-		os.Exit(1)
+	if app.Config.Server.IsAutologin {
+		err := s.Repository.InitAutologin()
+		if err != nil {
+			fmt.Printf("Could not initialize the autologin feature: %q\n", err)
+			os.Exit(1)
+		}
 	}
 
 	jobs.ScheduleCronJobs(s.Repository, s.Files, s.Email)
 
 	fmt.Printf("Serving on %s\n", app.Config.Address())
-	err = httpServer.ListenAndServe()
+	err := httpServer.ListenAndServe()
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/internal/services/sqlite_service.go
+++ b/internal/services/sqlite_service.go
@@ -29,7 +29,7 @@ var embedMigrations embed.FS
 
 const (
 	shortCtxTimeout  = 3 * time.Second
-	longerCtxTimeout = 1 * time.Minute
+	longerCtxTimeout = 5 * time.Minute
 )
 
 // SQLiteService represents the Service implemented with SQLite.
@@ -765,7 +765,7 @@ func (s *SQLiteService) InitAutologin() error {
 		log.Println("Created user for autologin with email 'admin@autologin.com' and password 'admin'")
 	}
 
-	return err
+	return nil
 }
 
 // IsUserExist checks whether the user is present in the database.

--- a/internal/services/sqlite_service.go
+++ b/internal/services/sqlite_service.go
@@ -143,6 +143,9 @@ func (s *SQLiteService) AddRecipe(r *models.Recipe, userID int64, settings model
 	ctx, cancel := context.WithTimeout(context.Background(), longerCtxTimeout)
 	defer cancel()
 
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
+
 	var isRecipeExists bool
 	err := s.DB.QueryRowContext(ctx, statements.IsRecipeForUserExist, userID, r.Name, r.Description, r.Yield, r.URL).Scan(&isRecipeExists)
 	if err != nil {
@@ -150,7 +153,7 @@ func (s *SQLiteService) AddRecipe(r *models.Recipe, userID int64, settings model
 	}
 
 	if isRecipeExists {
-		return 0, fmt.Errorf("recipe %q exists for user %d", r.Name, userID)
+		return 0, fmt.Errorf("recipe exists for user %d", userID)
 	}
 
 	if settings.ConvertAutomatically {
@@ -159,9 +162,6 @@ func (s *SQLiteService) AddRecipe(r *models.Recipe, userID int64, settings model
 			r = converted
 		}
 	}
-
-	s.Mutex.Lock()
-	defer s.Mutex.Unlock()
 
 	tx, err := s.DB.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {


### PR DESCRIPTION
We should now be able to add thousands of recipes in one go without worrying about dreadful errors.

![import-success-yay](https://github.com/reaper47/recipya/assets/5367592/0434f3ec-e99c-4543-8572-65302b7b6663)
