### PR TITLE
Scrape the main image on JSON+LD import

### DIFF
--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -67,10 +67,12 @@ func (s *Scraper) Scrape(url string, files services.FilesService) (models.Recipe
 		rs.URL = url
 	}
 
-	rs.Image.Value, err = files.ScrapeAndStoreImage(rs.Image.Value)
+	imageUUID, err := files.ScrapeAndStoreImage(rs.Image.Value)
 	if err != nil {
 		return rs, err
 	}
+
+	rs.Image.Value = imageUUID.String()
 	return rs, nil
 }
 

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -67,29 +67,9 @@ func (s *Scraper) Scrape(url string, files services.FilesService) (models.Recipe
 		rs.URL = url
 	}
 
-	if rs.Image.Value != "" {
-		resImage, err := http.Get(rs.Image.Value)
-		if err != nil {
-			return rs, err
-		}
-		defer func() {
-			_ = resImage.Body.Close()
-		}()
-
-		if resImage == nil {
-			return rs, errors.New("image response is nil")
-		}
-
-		body = resImage.Body
-		if body == nil {
-			return rs, errors.New("image response body is nil")
-		}
-
-		imageUUID, err := files.UploadImage(body)
-		if err != nil {
-			return rs, err
-		}
-		rs.Image.Value = imageUUID.String()
+	rs.Image.Value, err = files.ScrapeAndStoreImage(rs.Image.Value)
+	if err != nil {
+		return rs, err
 	}
 	return rs, nil
 }

--- a/internal/server/handlers_recipes_test.go
+++ b/internal/server/handlers_recipes_test.go
@@ -549,6 +549,7 @@ func TestHandlers_Recipes_AddWebsite(t *testing.T) {
 	originalBrokers := maps.Clone(srv.Brokers)
 	originalRepo := srv.Repository
 	originalScraper := srv.Scraper
+	originalFiles := srv.Files
 
 	uri := ts.URL + "/recipes/add/website"
 
@@ -593,6 +594,7 @@ func TestHandlers_Recipes_AddWebsite(t *testing.T) {
 
 	t.Run("add one valid URL from unsupported websites", func(t *testing.T) {
 		repo := prepare()
+		srv.Files = &mockFiles{}
 		srv.Scraper = &mockScraper{
 			scraperFunc: func(_ string, _ services.FilesService) (models.RecipeSchema, error) {
 				return models.RecipeSchema{}, errors.New("unsupported website")
@@ -601,6 +603,7 @@ func TestHandlers_Recipes_AddWebsite(t *testing.T) {
 		defer func() {
 			srv.Repository = originalRepo
 			srv.Scraper = originalScraper
+			srv.Files = originalFiles
 		}()
 
 		rr := sendHxRequestAsLoggedIn(srv, http.MethodPost, uri, formHeader, strings.NewReader("urls=https://www.example.com"))

--- a/internal/server/server_mock_test.go
+++ b/internal/server/server_mock_test.go
@@ -863,6 +863,10 @@ func (m *mockFiles) UploadImage(rc io.ReadCloser) (uuid.UUID, error) {
 	return uuid.New(), nil
 }
 
+func (m *mockFiles) ScrapeAndStoreImage(rawURL string) (string, error) {
+	return uuid.New().String(), nil
+}
+
 type mockIntegrations struct {
 	NextcloudImportFunc func(baseURL, username, password string, files services.FilesService) (*models.Recipes, error)
 	ProcessImageOCRFunc func(file io.Reader) (models.Recipe, error)

--- a/internal/server/server_mock_test.go
+++ b/internal/server/server_mock_test.go
@@ -863,8 +863,8 @@ func (m *mockFiles) UploadImage(rc io.ReadCloser) (uuid.UUID, error) {
 	return uuid.New(), nil
 }
 
-func (m *mockFiles) ScrapeAndStoreImage(rawURL string) (string, error) {
-	return uuid.New().String(), nil
+func (m *mockFiles) ScrapeAndStoreImage(rawURL string) (uuid.UUID, error) {
+	return uuid.New(), nil
 }
 
 type mockIntegrations struct {

--- a/internal/services/files.go
+++ b/internal/services/files.go
@@ -1003,12 +1003,7 @@ func (f *Files) extractRecipe(rd io.Reader) (*models.Recipe, error) {
 	}
 
 	if rs.Image.Value != "" {
-		imageUUID, err := f.ScrapeAndStoreImage(rs.Image.Value)
-		if err != nil {
-			imageUUID = uuid.Nil.String()
-		}
-
-		r.Image, err = uuid.Parse(imageUUID)
+		r.Image, err = f.ScrapeAndStoreImage(rs.Image.Value)
 		if err != nil {
 			r.Image = uuid.Nil
 		}
@@ -1017,33 +1012,34 @@ func (f *Files) extractRecipe(rd io.Reader) (*models.Recipe, error) {
 	return r, err
 }
 
-func (f *Files) ScrapeAndStoreImage(rawURL string) (string, error) {
+// ScrapeAndStoreImage takes a URL as input and will download and store the image, and return a UUID referencing the image's internal ID
+func (f *Files) ScrapeAndStoreImage(rawURL string) (uuid.UUID, error) {
 	if rawURL != "" {
 		resImage, err := http.Get(rawURL)
 		if err != nil {
-			return uuid.Nil.String(), err
+			return uuid.Nil, err
 		}
 		defer func() {
 			_ = resImage.Body.Close()
 		}()
 
 		if resImage == nil {
-			return uuid.Nil.String(), errors.New("image response is nil")
+			return uuid.Nil, errors.New("image response is nil")
 		}
 
 		if resImage.Body == nil {
-			return uuid.Nil.String(), errors.New("image response body is nil")
+			return uuid.Nil, errors.New("image response body is nil")
 		}
 
 		imageUUID, err := f.UploadImage(resImage.Body)
 		if err != nil {
-			return uuid.Nil.String(), nil
+			return uuid.Nil, nil
 		}
 
-		return imageUUID.String(), nil
+		return imageUUID, nil
 	}
 
-	return uuid.Nil.String(), nil
+	return uuid.Nil, nil
 }
 
 // ExportCookbook exports the cookbook in the desired file type.

--- a/internal/services/service.go
+++ b/internal/services/service.go
@@ -223,6 +223,8 @@ type FilesService interface {
 	// ExtractRecipes extracts the recipes from the HTTP files.
 	ExtractRecipes(fileHeaders []*multipart.FileHeader) models.Recipes
 
+	ScrapeAndStoreImage(rawURL string) (string, error)
+
 	// ExtractUserBackup extracts data from the user backup for restoration.
 	ExtractUserBackup(date string, userID int64) (*models.UserBackup, error)
 

--- a/internal/services/service.go
+++ b/internal/services/service.go
@@ -223,7 +223,8 @@ type FilesService interface {
 	// ExtractRecipes extracts the recipes from the HTTP files.
 	ExtractRecipes(fileHeaders []*multipart.FileHeader) models.Recipes
 
-	ScrapeAndStoreImage(rawURL string) (string, error)
+	// ScrapeAndStoreImage takes a URL as input and will download and store the image, and return a UUID referencing the image's internal ID
+	ScrapeAndStoreImage(rawURL string) (uuid.UUID, error)
 
 	// ExtractUserBackup extracts data from the user backup for restoration.
 	ExtractUserBackup(date string, userID int64) (*models.UserBackup, error)


### PR DESCRIPTION
Still in early testing, but thought this might be a way to handle the last comment on 
https://github.com/reaper47/recipya/pull/224#discussion_r1500390686
> Fix up or enhance JSON+LD import to pull the image on import

* Refactors image scraping code into files service's `ScrapeAndStoreImage` function
* A few minor changes in files service to ensure `extractRecipe` function has access to newly extracted `ScrapeAndStoreImage` function
* if `rs.Image.Value` is not a valid / parsed UUID, then treat it like a URL:
  * downlaod the image
  * store in files service
  * return the newly downloaded image's UUID to continue

Sorry, this one is pretty rough (as is my Golang).