### PR TITLE
Support importing recipes from Paprika

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -40,6 +40,10 @@
         <method importPath="net" receiver="Conn" name="Close" />
         <method importPath="github.com/gorilla/websocket" receiver="*Conn" name="Close" />
         <method importPath="net" receiver="Listener" name="Close" />
+        <method importPath="compress/gzip" receiver="*Reader" name="Close" />
+        <method importPath="io" receiver="*PipeWriter" name="Close" />
+        <method importPath="io" receiver="*PipeWriter" name="CloseWithError" />
+        <method importPath="io" receiver="*PipeReader" name="Close" />
       </methods>
     </inspection_tool>
     <inspection_tool class="HtmlUnknownAttribute" enabled="true" level="WARNING" enabled_by_default="true">

--- a/.idea/recipya-htmx.iml
+++ b/.idea/recipya-htmx.iml
@@ -7,6 +7,7 @@
       <excludeFolder url="file://$MODULE_DIR$/internal/scraper/testdata" />
       <excludeFolder url="file://$MODULE_DIR$/internal/units/lang" />
       <excludeFolder url="file://$MODULE_DIR$/internal/server/testdata" />
+      <excludeFolder url="file://$MODULE_DIR$/docs/website/themes" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,28 +11,28 @@
             "cwd": "${workspaceFolder}/bin",
             "program": "${workspaceFolder}/main.go",
             "args": [
-                "serve",
+                "serve"
             ],
             "env": {
                 "RECIPYA_SERVER_URL": "localhost",
                 "RECIPYA_SERVER_PORT": "8079",
                 "RECIPYA_SERVER_AUTOLOGIN": "true",
                 "RECIPYA_SERVER_IS_DEMO": "true",
-                "RECIPYA_SERVER_NO_SIGNUPS": "true",
+                "RECIPYA_SERVER_NO_SIGNUPS": "true"
             },
 
             "serverReadyAction": {
                 "pattern": "Serving on localhost:8079",
                 "uriFormat": "http://localhost:8079",
-                "action": "openExternally",
-            },
+                "action": "openExternally"
+            }
         },
         {
             "name": "Attach to Process",
             "type": "go",
             "request": "attach",
             "mode": "local",
-            "processId": 0,
+            "processId": 0
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,7 +7,7 @@
             "command": "go",
             "args": [
                 "mod",
-                "tidy",
+                "tidy"
             ]
         },
         {
@@ -33,7 +33,7 @@
             "command": "templ",
             "args": [
                 "generate",
-                "-watch",
+                "-watch"
             ]
         },
         {
@@ -42,11 +42,11 @@
             "command": "hugo",
             "args": [
                 "server",
-                "--navigateToChanged",
+                "--navigateToChanged"
             ],
             "options": {
                 "cwd": "${workspaceFolder}/docs/website"
-            },
+            }
         }
     ]
 }

--- a/docs/website/content/about/changelog/v1.2.0.md
+++ b/docs/website/content/about/changelog/v1.2.0.md
@@ -24,3 +24,15 @@ Please ensure to adjust your volume path to
 
 A logging mechanism has been introduced using [log/slog](https://pkg.go.dev/log/slog). The logs are stored 
 under `%APPDATA%\Recipya\Logs`. Logs rotate once a log file's size reaches 500MB. Up to three log files are stored at a time.
+
+## Recipes
+
+### Import
+
+It is now possible to import recipes from Paprika. To do so:
+
+1. [Export](https://www.paprikaapp.com/help/windows/#exportrecipes) your Paprika recipes in the `Paprika Recipe Format`.
+2. Within Recipya, click the `Add recipe` button.
+3. Click the `Import` button.
+4. Select your `.paprikarecipes` file. You may also zip many `.paprikarecipes` together and select the resulting file.
+5. Click `Submit`.

--- a/docs/website/content/docs/deployment/local-network.md
+++ b/docs/website/content/docs/deployment/local-network.md
@@ -30,6 +30,7 @@ Wants=network.target
 
 [Service]
 ExecStart=/path/to/binary/recipya serve
+Environment=HOME=/root
 
 [Install]
 WantedBy=multi-user.target

--- a/docs/website/content/docs/features/recipes/add.md
+++ b/docs/website/content/docs/features/recipes/add.md
@@ -68,7 +68,8 @@ support for the website by clicking the button that appears.
 
 You can import recipes in the following formats:
 - `.json`: If they adhere to the [Recipe schema](https://schema.org/Recipe) standard
-- `.mxp`: Exported recipes from [MasterCook](https://www.mastercook.com)  
+- `.mxp`: Exported recipes from [MasterCook](https://www.mastercook.com)
+- `.paprikarecipes`: Exported recipes from [Paprika](https://www.paprikaapp.com) in the `Paprika Recipe Format`
 - `.txt`
 
 ![](images/add-recipe-import.webp)

--- a/internal/models/file-types.go
+++ b/internal/models/file-types.go
@@ -7,6 +7,7 @@ const (
 	JSON FileType = iota
 	PDF
 	MXP
+	Paprika
 	TXT
 	InvalidFileType
 )
@@ -19,10 +20,12 @@ func NewFileType(fileType string) FileType {
 	switch strings.ToLower(fileType) {
 	case "json":
 		return JSON
-	case "pdf":
-		return PDF
 	case "mxp":
 		return MXP
+	case "paprikarecipes":
+		return Paprika
+	case "pdf":
+		return PDF
 	case "txt":
 		return TXT
 	default:
@@ -35,10 +38,12 @@ func (f FileType) Ext() string {
 	switch f {
 	case JSON:
 		return ".json"
-	case PDF:
-		return ".pdf"
 	case MXP:
 		return ".mxp"
+	case Paprika:
+		return ".paprikarecipes"
+	case PDF:
+		return ".pdf"
 	case TXT:
 		return ".txt"
 	default:

--- a/internal/models/file-types_test.go
+++ b/internal/models/file-types_test.go
@@ -12,8 +12,9 @@ func TestFileType_Ext(t *testing.T) {
 		want string
 	}{
 		{name: "json", in: models.JSON, want: ".json"},
-		{name: "pdf", in: models.PDF, want: ".pdf"},
 		{name: "mxp", in: models.MXP, want: ".mxp"},
+		{name: "paprika", in: models.Paprika, want: ".paprikarecipes"},
+		{name: "pdf", in: models.PDF, want: ".pdf"},
 		{name: "txt", in: models.TXT, want: ".txt"},
 		{name: "invalid", in: models.InvalidFileType, want: ""},
 	}
@@ -34,8 +35,9 @@ func TestNewFileType(t *testing.T) {
 		want models.FileType
 	}{
 		{name: "json", in: "json", want: models.JSON},
-		{name: "pdf", in: "pdf", want: models.PDF},
 		{name: "mxp", in: "mxp", want: models.MXP},
+		{name: "paprikarecipes", in: "paprikarecipes", want: models.Paprika},
+		{name: "pdf", in: "pdf", want: models.PDF},
 		{name: "txt", in: "txt", want: models.TXT},
 		{name: "invalid", in: "", want: models.InvalidFileType},
 	}

--- a/internal/models/integrations_test.go
+++ b/internal/models/integrations_test.go
@@ -1,0 +1,85 @@
+package models_test
+
+import (
+	"encoding/json"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+	"github.com/reaper47/recipya/internal/models"
+	"testing"
+	"time"
+)
+
+func TestPaprikaRecipe_Recipe(t *testing.T) {
+	data := `{"uid": "CF0EB3F6-A5AE-49CC-BDEF-D5B406F6C34C","created": "2024-04-09 05:42:31","hash": "08821A86BC2BE19727844C3A2A59C002A70B979DF1A3CE4A64DB5AD24233D611","name": "Guyanese Gojas","description": "","ingredients": "For the goja dough:\n2 cups (240g) all-purpose flour\n2 teaspoons (8g) granulated sugar\n1/2 teaspoon (2g) instant yeast\n2 tablespoons diced cold butter, or vegetable shortening\n1 cup cold whole milk\n1 tablespoon (15g) all-purpose flour, to sprinkle while kneading\n1/8 teaspoon neutral cooking oil, such as canola or vegetable for rubbing the dough ball\nFor the goja filling:\n2 cups sweetened flaked coconut\n1/2 teaspoon ground cinnamon\n1/2 teaspoon freshly grated nutmeg\n1 tablespoon light brown sugar\n1 tablespoon fresh grated ginger\n2 tablespoons water\n2 tablespoons butter, melted\n2 teaspoons vanilla extract\n2 tablespoons neutral cooking oil such as canola or vegetable, for cooking filling\n1/4 cup raisins\n2 tablespoons water, for cooking filling\nFor shaping and frying the gojas:\n1/4 cup water, for sealing the pastry\n1/4 cup (34g) all-purpose flour, for crimping the gojas\n3 cups canola or vegetable oil, for frying","directions": "Combine the dry ingredients :\n\nIn a large bowl, combine the flour, sugar, and yeast. Add the butter. Using your hands or fingertips, rub the butter into flour until a coarse meal forms.\n\nAlica Ramkirpal-Senhouse / Simply Recipes\n\nAlica Ramkirpal-Senhouse / Simply Recipes\n\nPour milk into bowl:\n\nMake a well in the center of the bowl, pour in the milk. Using a rubber spatula, stir until the dough forms. At this point, the dough will be a little sticky, sprinkle 1 tablespoon flour on the dough and knead it into dough with your hands in the bowl until the dough is no longer sticky.\n\nSet dough aside to rest:\n\nRub the top of the dough with the oil and cover with a damp paper towel. Set aside for 15 to 20 minutes.\n\nMake the filling:\n\nIn the bowl of your food processor, add the coconut, cinnamon, nutmeg, brown sugar, ginger, water, butter, and vanilla. Pulse on high until coconut becomes fine and pasty.\n\nCook the filling:\n\nHeat a heavy-bottomed pan over low heat. Add the oil, coconut filling, raisins, and 2 tablespoons of water. Cook, stirring occasionally, until the sugar melts and the coconut looks more toasted and slightly darker in color, about 5 minutes. Remove from heat and let cool for a few minutes before assembling the gojas.\n\nAlica Ramkirpal-Senhouse / Simply Recipes\n\nWeigh and divide the dough:\n\nWeigh the dough, then divide the weight by 12 to get the weight for each piece. Now, cut 12 small pieces of dough and weigh each. Add or remove small pieces until you get the exact weight you’re looking for.\n\nIf you’re not using a scale, divide the dough into 12 pieces using a knife or pastry cutter. Try to eyeball it so they’re all the same size.\n\nAlica Ramkirpal-Senhouse / Simply Recipes\n\nRoll the goja dough:\n\nRound off each dough ball between your palms to form a ball, gently tucking dough under itself to make the top smooth. Once you’ve done this, cover all the dough balls with a damp paper towel to keep it from drying out and crusting.\n\nSprinkle flour on the surface of the dough ball you are working with. Working with one dough ball at a time, flatten slightly with your hands, then roll into a circle 1/8 inch thick and about 5 inches in diameter.\n\nFlour your surface as needed as you go along.\n\nRepeat with remaining balls of dough, being sure to keep them covered as you work.\n\nDip your pointer finger in water and run it around the outer edges of the dough. Place 2 tablespoons filing in the bottom half of the dough and bring the top half over to seal. Using a fork crimp the edges closed being sure to dip the fork in flour to keep from sticking while crimping. Place assembled gojas on a baking sheet lined with parchment paper.\n\nRepeat this step for the rest of the batch.\n\nSet up a plate or deep serving platter with a few paper towels to place gojas on after they’re done frying.\n\nHeat a medium sized deep pot over medium-low heat. Add the oil and once it’s anywhere between 350-375°F, fry the gojas for 2 to 3 minutes, you’ll have to cook these in batches, being sure to not overcrowd the pot. Use a slotted spoon or tongs to flip the gojas once halfway through cooking. Remove from oil once it is light golden brown and drain on paper towels.\n\nRepeat with remaining gojas until they are all fried.\n\nEnjoy warm.\n\nAlica Ramkirpal-Senhouse / Simply Recipes","notes": "","nutritional_info": "(per serving)\n543 Calories 30g Fat 62g Carbs 8g Protein\nNutrition Facts\nServings: 6\nAmount per serving\nCalories 543\n% Daily Value*\nTotal Fat 30g 38%\nSaturated Fat 13g 67%\nCholesterol 17mg 6%\nSodium 132mg 6%\nTotal Carbohydrate 62g 23%\nDietary Fiber 5g 16%\nTotal Sugars 20g\nProtein 8g\nVitamin C 0mg 1%\nCalcium 66mg 5%\nIron 3mg 16%\nPotassium 271mg 6%\n*The % Daily Value (DV) tells you how much a nutrient in a food serving contributes to a daily diet. 2,000 calories a day is used for general nutrition advice.","prep_time": "65 mins","cook_time": "35 mins","total_time": "","difficulty": "Medium","servings": "6 servings","rating": 0,"source": "Simplyrecipes.com","source_url": "https://www.simplyrecipes.com/guyanese-gojas-recipe-5221034","photo": "57C135F8-0CF2-40F2-89C0-0F7BCFFCF0F4.jpg","photo_large": null,"photo_hash": "3F1AB2130588CB3AEA727B0AAF0F24358921197A12036CF283BEBA9E0C60102C","image_url": "https://www.simplyrecipes.com/thmb/07pz2tqpdKhQdNId5mCQVE58fVw=/750x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/Simply-Recipes-Guyanese-Gojas-LEAD-09-712f8f32ffff41b4b4cdd2f91c0f8b74.jpg","categories": [],"photos": []}`
+	var p models.PaprikaRecipe
+	_ = json.Unmarshal([]byte(data), &p)
+
+	got := p.Recipe(uuid.Nil)
+
+	want := models.Recipe{
+		Category:  "uncategorized",
+		CreatedAt: got.CreatedAt,
+		Image:     uuid.Nil,
+		Ingredients: []string{
+			"For the goja dough:", "2 cups (240g) all-purpose flour",
+			"2 teaspoons (8g) granulated sugar", "1/2 teaspoon (2g) instant yeast",
+			"2 tablespoons diced cold butter, or vegetable shortening",
+			"1 cup cold whole milk",
+			"1 tablespoon (15g) all-purpose flour, to sprinkle while kneading",
+			"1/8 teaspoon neutral cooking oil, such as canola or vegetable for rubbing the dough ball",
+			"For the goja filling:", "2 cups sweetened flaked coconut",
+			"1/2 teaspoon ground cinnamon", "1/2 teaspoon freshly grated nutmeg",
+			"1 tablespoon light brown sugar", "1 tablespoon fresh grated ginger",
+			"2 tablespoons water", "2 tablespoons butter, melted",
+			"2 teaspoons vanilla extract",
+			"2 tablespoons neutral cooking oil such as canola or vegetable, for cooking filling",
+			"1/4 cup raisins",
+			"2 tablespoons water, for cooking filling",
+			"For shaping and frying the gojas:",
+			"1/4 cup water, for sealing the pastry",
+			"1/4 cup (34g) all-purpose flour, for crimping the gojas",
+			"3 cups canola or vegetable oil, for frying",
+		},
+		Instructions: []string{
+			"Combine the dry ingredients :",
+			"In a large bowl, combine the flour, sugar, and yeast. Add the butter. Using your hands or fingertips, rub the butter into flour until a coarse meal forms.",
+			"Alica Ramkirpal-Senhouse / Simply Recipes",
+			"Alica Ramkirpal-Senhouse / Simply Recipes", "Pour milk into bowl:",
+			"Make a well in the center of the bowl, pour in the milk. Using a rubber spatula, stir until the dough forms. At this point, the dough will be a little sticky, sprinkle 1 tablespoon flour on the dough and knead it into dough with your hands in the bowl until the dough is no longer sticky.",
+			"Set dough aside to rest:",
+			"Rub the top of the dough with the oil and cover with a damp paper towel. Set aside for 15 to 20 minutes.",
+			"Make the filling:",
+			"In the bowl of your food processor, add the coconut, cinnamon, nutmeg, brown sugar, ginger, water, butter, and vanilla. Pulse on high until coconut becomes fine and pasty.",
+			"Cook the filling:",
+			"Heat a heavy-bottomed pan over low heat. Add the oil, coconut filling, raisins, and 2 tablespoons of water. Cook, stirring occasionally, until the sugar melts and the coconut looks more toasted and slightly darker in color, about 5 minutes. Remove from heat and let cool for a few minutes before assembling the gojas.",
+			"Alica Ramkirpal-Senhouse / Simply Recipes",
+			"Weigh and divide the dough:",
+			"Weigh the dough, then divide the weight by 12 to get the weight for each piece. Now, cut 12 small pieces of dough and weigh each. Add or remove small pieces until you get the exact weight you’re looking for.",
+			"If you’re not using a scale, divide the dough into 12 pieces using a knife or pastry cutter. Try to eyeball it so they’re all the same size.",
+			"Alica Ramkirpal-Senhouse / Simply Recipes",
+			"Roll the goja dough:",
+			"Round off each dough ball between your palms to form a ball, gently tucking dough under itself to make the top smooth. Once you’ve done this, cover all the dough balls with a damp paper towel to keep it from drying out and crusting.",
+			"Sprinkle flour on the surface of the dough ball you are working with. Working with one dough ball at a time, flatten slightly with your hands, then roll into a circle 1/8 inch thick and about 5 inches in diameter.",
+			"Flour your surface as needed as you go along.",
+			"Repeat with remaining balls of dough, being sure to keep them covered as you work.",
+			"Dip your pointer finger in water and run it around the outer edges of the dough. Place 2 tablespoons filing in the bottom half of the dough and bring the top half over to seal. Using a fork crimp the edges closed being sure to dip the fork in flour to keep from sticking while crimping. Place assembled gojas on a baking sheet lined with parchment paper.",
+			"Repeat this step for the rest of the batch.",
+			"Set up a plate or deep serving platter with a few paper towels to place gojas on after they’re done frying.",
+			"Heat a medium sized deep pot over medium-low heat. Add the oil and once it’s anywhere between 350-375°F, fry the gojas for 2 to 3 minutes, you’ll have to cook these in batches, being sure to not overcrowd the pot. Use a slotted spoon or tongs to flip the gojas once halfway through cooking. Remove from oil once it is light golden brown and drain on paper towels.",
+			"Repeat with remaining gojas until they are all fried.",
+			"Enjoy warm.",
+			"Alica Ramkirpal-Senhouse / Simply Recipes",
+		},
+		Keywords:  []string{"paprika"},
+		Name:      "Guyanese Gojas",
+		Times:     models.Times{Prep: 1*time.Hour + 5*time.Minute, Cook: 35 * time.Minute},
+		Tools:     []string{},
+		UpdatedAt: got.UpdatedAt,
+		URL:       "https://www.simplyrecipes.com/guyanese-gojas-recipe-5221034",
+		Yield:     6,
+	}
+	if !cmp.Equal(got, want) {
+		t.Log(cmp.Diff(got, want))
+		t.Fail()
+	}
+}

--- a/internal/server/server_mock_test.go
+++ b/internal/server/server_mock_test.go
@@ -875,7 +875,7 @@ func (m *mockFiles) ExtractRecipes(fileHeaders []*multipart.FileHeader) models.R
 	return models.Recipes{}
 }
 
-func (m *mockFiles) IsAppLatest(current semver.Version) (bool, *github.RepositoryRelease, error) {
+func (m *mockFiles) IsAppLatest(_ semver.Version) (bool, *github.RepositoryRelease, error) {
 	return true, nil, nil
 }
 

--- a/internal/services/statements/select.go
+++ b/internal/services/statements/select.go
@@ -315,9 +315,7 @@ func BuildBaseSelectRecipe(sorts models.Sort) string {
 	before, after, _ := strings.Cut(baseSelectSearchRecipe, "ROW_NUMBER() OVER (ORDER BY recipes.id) AS row_num")
 	var sb strings.Builder
 	sb.WriteString(before)
-	if s != "" {
-		sb.WriteString(" ROW_NUMBER() OVER (ORDER BY " + s + ") AS row_num")
-	}
+	sb.WriteString(" ROW_NUMBER() OVER (ORDER BY " + s + ") AS row_num")
 	sb.WriteString(after)
 	return sb.String()
 }

--- a/web/components/recipes.templ
+++ b/web/components/recipes.templ
@@ -169,10 +169,11 @@ templ addRecipe() {
 			<div class="card-body">
 				<h2 class="card-title">Import</h2>
 				<p>
-					Import recipes that adhere to the
-					<a href="https://schema.org/Recipe" target="_blank" class="link">recipe schema</a>
-					standard, the <a href="https://www.mastercook.com/" target="_blank" class="link">MasterCook</a> file
-					format, or as plain text files.
+					Import recipes from
+					<a href="https://www.paprikaapp.com/" target="_blank" class="link">Paprika</a>,
+					<a href="https://www.mastercook.com/" target="_blank" class="link">MasterCook</a>,
+					plain text files
+					or files that adhere to the <a href="https://schema.org/Recipe" target="_blank" class="link">recipe schema</a> standard.
 				</p>
 				<p>
 					You can also download recipe schema files directly using the
@@ -180,14 +181,14 @@ templ addRecipe() {
 						class="link tooltip"
 						data-tip="Simply drag this link to your bookmarks bar, and click the bookmark while on a recipe website.  If a recipe schema downloads successfully, you can import it here."
 						href="javascript:(function(){
-							const recipeCount = 0;
+							let recipeCount = 0;
 							const jsonSchemaScripts = ([...document.querySelectorAll('script[type=%22application/ld+json%22]')]);
 							for (const jsonSchemaScript of jsonSchemaScripts) {
 								let data = JSON.parse(jsonSchemaScript.innerHTML);
 								if (Array.isArray(data) && data.length > 0) {
 									data = data[0];
 								}
-								if (data['@type'] != 'Recipe') {
+								if (data['@type'] !== 'Recipe') {
 									continue;
 								}
 								const blob = new Blob([JSON.stringify(data)]);
@@ -229,13 +230,13 @@ templ addRecipe() {
 				>
 					<div class="grid mb-4">
 						<label for="import-dialog-file" class="text-sm font-semibold mb-1">
-							Choose files in the .json, .mxp or .zip format.
+							Choose files in the .json, .mxp, .paprikarecipes or .zip format.
 						</label>
 						<input
 							id="import-dialog-file"
 							type="file"
 							name="files"
-							accept=".json,.zip,.mxp"
+							accept=".json,.zip,.mxp,.paprikarecipes"
 							multiple
 							class="p-2 border border-gray-300 rounded-lg shadow focus:ring-2 focus:ring-purple-600 dark:bg-gray-900 dark:border-none"
 						/>


### PR DESCRIPTION
It is now possible to import recipes from Paprika. To do so:

1. [Export](https://www.paprikaapp.com/help/windows/#exportrecipes) your Paprika recipes in the `Paprika Recipe Format`.
2. Within Recipya, click the `Add recipe` button.
3. Click the `Import` button.
4. Select your `.paprikarecipes` file. You may also zip many `.paprikarecipes` together and select the resulting file.
5. Click `Submit`.

Video demonstration:
![import-paprika](https://github.com/reaper47/recipya/assets/5367592/f4ab26cd-4cf7-4824-904b-a8ecc87fd403)

