### PR TITLE
Drop support for some platforms

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.22
 
@@ -29,7 +29,7 @@ jobs:
         run: go install github.com/a-h/templ/cmd/templ@latest
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
           hugo-version: "latest"
           extended: true

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -37,7 +37,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.22
 
@@ -45,7 +45,7 @@ jobs:
         run: go install github.com/a-h/templ/cmd/templ@latest
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
           hugo-version: "latest"
           extended: true

--- a/docs/website/content/about/changelog/v1.2.0.md
+++ b/docs/website/content/about/changelog/v1.2.0.md
@@ -291,6 +291,12 @@ Fix missing closing parenthesis to the first column header of the nutrition tabl
 
 ### General
 
+Dropped support for the following platforms because the software wouldn't compile:
+- Linux on 32-bit x86 architecture (linux/386).
+- Linux on ARMv6 architecture (linux/arm)
+- Linux on 64-bit RISC-V architecture (linux/riscv64)
+- Linux on IBM System z architecture (linux/s390x)
+
 Improved parsing of maangchi.com.
 
 Websites previously approved, but failed when added through the UI, have been fixed.

--- a/docs/website/content/docs/installation/system-requirements.md
+++ b/docs/website/content/docs/installation/system-requirements.md
@@ -13,12 +13,8 @@ The following table lists the supported platforms and devices.
 |---------------|----------------------------------------------|---------------------------------------------------------|
 | darwin/amd64  | macOS on 64-bit Intel (x86-64) architecture  | Apple MacBook, iMac, Mac Mini, Mac Pro                  |
 | darwin/arm64  | macOS on ARM64 architecture                  | MacBook Air (M1), MacBook Pro (M1), Mac Mini (M1)       |
-| linux/386     | Linux on 32-bit x86 architecture             | Older PCs, embedded systems                             |
 | linux/amd64   | Linux on 64-bit x86 architecture (x86-64)    | Desktops, laptops, servers, cloud instances             |
-| linux/arm     | Linux on ARMv6 architecture                  | Raspberry Pi 1st gen, IoT devices, some old smartphones |
 | linux/arm64   | Linux on ARMv8 64-bit architecture           | Raspberry Pi 3rd/4th gen, modern smartphones            |
-| linux/riscv64 | Linux on 64-bit RISC-V architecture          | RISC-V development boards, experimental devices         |
-| linux/s390x   | Linux on IBM System z architecture           | IBM mainframes, servers                                 |
 | windows/amd64 | Windows on 64-bit x86 architecture           | Modern Windows PCs, servers, virtual machines           |
 | windows/arm64 | Windows on ARM64 architecture                | Microsoft Surface Pro X, ARM-based Windows devices      |
 

--- a/releases/main.go
+++ b/releases/main.go
@@ -35,12 +35,8 @@ func buildRelease(packageName, tag string) {
 	platforms := []string{
 		"darwin/amd64",
 		"darwin/arm64",
-		"linux/386",
 		"linux/amd64",
-		"linux/arm",
 		"linux/arm64",
-		"linux/riscv64",
-		"linux/s390x",
 		"windows/amd64",
 		"windows/arm64",
 	}


### PR DESCRIPTION
Dropped support for the following platforms because the software wouldn't compile:
- Linux on 32-bit x86 architecture (linux/386).
- Linux on ARMv6 architecture (linux/arm)
- Linux on 64-bit RISC-V architecture (linux/riscv64)
- Linux on IBM System z architecture (linux/s390x)