### PR TITLE
Remove testing during Docker build

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -18,7 +18,6 @@ COPY ./main.go ./
 COPY ./docs ./docs
 COPY ./web ./web
 
-RUN go test ./... -v
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /app/recipya main.go
 
 # Deploy the application binary into a lean image


### PR DESCRIPTION
Few tests always fail during the Docker build because of the websocket, preventing the creation of a new nightly image.