### PR TITLE
Set org.opencontainers.image.source label in Dockerfile

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -20,6 +20,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /app/recipya main.go
 
 # Deploy the application binary into a lean image
 FROM alpine AS build-release-stage
+LABEL org.opencontainers.image.source="https://github.com/reaper47/recipya"
 
 WORKDIR /
 


### PR DESCRIPTION
As documented in the OCI Image Format, [org.opencontainers.image.source](https://github.com/opencontainers/image-spec/blob/5325ec48851022d6ded604199a3566254e72842a/annotations.md#L24) identifies an image's source repository. This is purely for documentation purposes. It does however help tools such as [Renovate](https://docs.renovatebot.com/modules/datasource/docker/#description) to find the changelogs when a new Recipya version is released. The changelogs would then be included in the PR Renovate creates.