### PR TITLE
Update Docs Link in deploy/compose.yml

### DIFF
--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -1,4 +1,4 @@
-# Documentation for the environment variables: https://recipes.musicavis.ca/guide/docs/installation/docker/#environment-variables
+# Documentation for the environment variables: https://recipes.musicavis.ca/docs/installation/docker/#environment-variables
 services:
   web:
     image: reaper99/recipya:nightly


### PR DESCRIPTION
Hi, I just set up the app for the first time (loving it so far btw) and noticed this error when following the configuration guide so thought I'd fix it for the next person.


The old link just redirects to you the demo page, this will take you to the correct docs page.