### PR TITLE
Update of the Dev Container to build the image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/go:1-1.22-bullseye
+FROM mcr.microsoft.com/devcontainers/go:1-1.23-bookworm
 
 RUN apt-get update && apt-get install -y curl wget git
 


### PR DESCRIPTION
Updating the go image to 1.23 that is required by the templ latest package