### PR TITLE
Revert "Adding armv7 arch for docker image (#513)"

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -61,7 +61,7 @@ jobs:
           # ...build this Dockerfile...
           file: ./deploy/Dockerfile
           # ...for the following platforms
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           push: true
           # Use the `tags` and `labels` parameters to tag and label the Docker image with the output from the "meta" step above
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
This reverts commit fd8a6cbcc07d4736f85bfab7c83a140f9f1c054b.

Sorry for the inconvenience, I've just realized, that you have purego in the dependencies, which doesn't support arm/v7. So the docker build fails with the error:

```
linux/arm/v7 build-stage 13/13] RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /app/recipya main.go:
24.74 # github.com/ebitengine/purego/internal/fakecgo
24.74 /go/pkg/mod/github.com/ebitengine/purego@v0.8.2/internal/fakecgo/callbacks.go:88:28: undefined: threadentry
24.74 /go/pkg/mod/github.com/ebitengine/purego@v0.8.2/internal/fakecgo/callbacks.go:89:28: undefined: x_cgo_init
24.74 /go/pkg/mod/github.com/ebitengine/purego@v0.8.2/internal/fakecgo/go_util.go:36:2: undefined: _cgo_sys_thread_star
```